### PR TITLE
Test to master and guard the not_found

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: c
 compiler:
   - gcc
 env:
-  - MRUBY_VERSION=1.2.0
   - MRUBY_VERSION=master
 matrix:
   allow_failures:

--- a/mrblib/etcd/client.rb
+++ b/mrblib/etcd/client.rb
@@ -49,6 +49,7 @@ module Etcd
     def get(key, raw=false)
       res = do_request("/keys/#{key}", :get)
       if res.is_a?(Hash)
+        return nil if res["errorCode"] == 100
         raw ? res : res['node']['value']
       else
         res
@@ -64,6 +65,7 @@ module Etcd
         raise "/keys/#{dir} is not a directory"
       end
       if raw
+        return [] if res["errorCode"] == 100
         res
       else
         res['node']['nodes']


### PR DESCRIPTION
haconiwa core say if there is no `haconiwa.mruby.org` key:

```
NoMethodError: undefined method '[]' for nil
```
